### PR TITLE
Problem: Repetitive clone and extend boilerplate when emitting events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ emitter.on('telemetry', function (event) {
 telemetry.emit({type: 'log', level: 'info', message: 'hello info level'});
 telemetry.emit({type: 'metric', name: 'web requests', target_type: 'counter', unit: 'Req', value: 1});
 
-var _methodMetadata = {
+var _commonEventData = {
     method: "readme",
     provenance: [{module: "my-module"}]
 };
-telemetry.emit(_methodMetadata,
+telemetry.emit(_commonEventData,
 {
     type: "log",
     level: "info",
     message: "info message using method metadata scaffold"
 });
-telemetry.emit(_methodMetadata,
+telemetry.emit(_commonEventData,
 {
     type: "metric",
     name: "metric with metadata",
@@ -80,7 +80,7 @@ telemetry.emit(_methodMetadata,
 **Public API**
 
   * [new TelemetryEvents(config)](#new-telemetryeventsconfig)
-  * [telemetry.emit(\[scaffold\], event)](#telemetryemitscaffold-event)
+  * [telemetry.emit(\[common\], event)](#telemetryemitcommon-event)
 
 ### new TelemetryEvents(config)
 
@@ -93,14 +93,14 @@ telemetry.emit(_methodMetadata,
 
 Creates a new TelemetryEvents instance.
 
-### telemetry.emit([scaffold], event)
+### telemetry.emit([common], event)
 
-  * `scaffold`: _Object_ _(Default: undefined)_ Optional scaffold to clone and extend with the `event` data.
+  * `common`: _Object_ _(Default: undefined)_ Optional common data to clone and extend with the `event` data.
   * `event`: _Object_ Event to be emitted.
   * Return: _Object_ The event.
 
 Adds or extends `event.provenance`. Adds `event.timestamp` if not present.
 
-If `emit(event)` is given a single argument, it will be treated as `event` and `scaffold` will be `undefined`.
+If `emit(event)` is given a single argument, it will be treated as `event` and `common` will be `undefined`.
 
 If `emitter` is not defined, this method does not emit the event. When `emitter` is defined, calling this method will emit the `event` using `eventName`, if provided, or "telemetry" (by default).

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ telemetry.emit(_commonEventData,
 {
     type: "log",
     level: "info",
-    message: "info message using method metadata scaffold"
+    message: "info message using common event data"
 });
 telemetry.emit(_commonEventData,
 {
     type: "metric",
-    name: "metric with metadata",
+    name: "metric with common event data",
     target_type: "counter",
     unit: "Call",
     value: 1

--- a/README.md
+++ b/README.md
@@ -46,6 +46,25 @@ emitter.on('telemetry', function (event) {
 telemetry.emit({type: 'log', level: 'info', message: 'hello info level'});
 telemetry.emit({type: 'metric', name: 'web requests', target_type: 'counter', unit: 'Req', value: 1});
 
+var _methodMetadata = {
+    method: "readme",
+    provenance: [{module: "my-module"}]
+};
+telemetry.emit(_methodMetadata,
+{
+    type: "log",
+    level: "info",
+    message: "info message using method metadata scaffold"
+});
+telemetry.emit(_methodMetadata,
+{
+    type: "metric",
+    name: "metric with metadata",
+    target_type: "counter",
+    unit: "Call",
+    value: 1
+});
+
 ```
 
 ## Tests
@@ -61,7 +80,7 @@ telemetry.emit({type: 'metric', name: 'web requests', target_type: 'counter', un
 **Public API**
 
   * [new TelemetryEvents(config)](#new-telemetryeventsconfig)
-  * [telemetry.emit(event)](#telemetryemitevent)
+  * [telemetry.emit(\[scaffold\], event)](#telemetryemitscaffold-event)
 
 ### new TelemetryEvents(config)
 
@@ -74,11 +93,14 @@ telemetry.emit({type: 'metric', name: 'web requests', target_type: 'counter', un
 
 Creates a new TelemetryEvents instance.
 
-### telemetry.emit(event)
+### telemetry.emit([scaffold], event)
 
+  * `scaffold`: _Object_ _(Default: undefined)_ Optional scaffold to clone and extend with the `event` data.
   * `event`: _Object_ Event to be emitted.
   * Return: _Object_ The event.
 
 Adds or extends `event.provenance`. Adds `event.timestamp` if not present.
+
+If `emit(event)` is given a single argument, it will be treated as `event` and `scaffold` will be `undefined`.
 
 If `emitter` is not defined, this method does not emit the event. When `emitter` is defined, calling this method will emit the `event` using `eventName`, if provided, or "telemetry" (by default).

--- a/examples/readme.js
+++ b/examples/readme.js
@@ -45,17 +45,17 @@ emitter.on('telemetry', function (event) {
 telemetry.emit({type: 'log', level: 'info', message: 'hello info level'});
 telemetry.emit({type: 'metric', name: 'web requests', target_type: 'counter', unit: 'Req', value: 1});
 
-var _methodMetadata = {
+var _commonEventData = {
     method: "readme",
     provenance: [{module: "my-module"}]
 };
-telemetry.emit(_methodMetadata,
+telemetry.emit(_commonEventData,
 {
     type: "log",
     level: "info",
     message: "info message using method metadata scaffold"
 });
-telemetry.emit(_methodMetadata,
+telemetry.emit(_commonEventData,
 {
     type: "metric",
     name: "metric with metadata",

--- a/examples/readme.js
+++ b/examples/readme.js
@@ -4,7 +4,7 @@ readme.js: example from the README
 
 The MIT License (MIT)
 
-Copyright (c) 2014 Tristan Slominski, Leora Pearson
+Copyright (c) 2014-2015 Tristan Slominski, Leora Pearson
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation
@@ -44,3 +44,22 @@ emitter.on('telemetry', function (event) {
 
 telemetry.emit({type: 'log', level: 'info', message: 'hello info level'});
 telemetry.emit({type: 'metric', name: 'web requests', target_type: 'counter', unit: 'Req', value: 1});
+
+var _methodMetadata = {
+    method: "readme",
+    provenance: [{module: "my-module"}]
+};
+telemetry.emit(_methodMetadata,
+{
+    type: "log",
+    level: "info",
+    message: "info message using method metadata scaffold"
+});
+telemetry.emit(_methodMetadata,
+{
+    type: "metric",
+    name: "metric with metadata",
+    target_type: "counter",
+    unit: "Call",
+    value: 1
+});

--- a/examples/readme.js
+++ b/examples/readme.js
@@ -53,12 +53,12 @@ telemetry.emit(_commonEventData,
 {
     type: "log",
     level: "info",
-    message: "info message using method metadata scaffold"
+    message: "info message using common event data"
 });
 telemetry.emit(_commonEventData,
 {
     type: "metric",
-    name: "metric with metadata",
+    name: "metric with common event data",
     target_type: "counter",
     unit: "Call",
     value: 1

--- a/index.js
+++ b/index.js
@@ -68,21 +68,21 @@ function TelemetryEvents(config) {
 };
 
 /*
-  * `scaffold`: _Object_ _(Default: undefined)_ Optional scaffold to clone and
-      extend with the `event` data.
+  * `common`: _Object_ _(Default: undefined)_ Optional common event data to
+      clone and extend with the `event` data.
   * `event`: _Object_ Event to be emitted.
   * Return: _Object_ The event.
  */
-TelemetryEvents.prototype.emit = function emit(scaffold, event)
+TelemetryEvents.prototype.emit = function emit(common, event)
 {
     var self = this;
     if (event === undefined)
     {
-        event = scaffold;
+        event = common;
     }
     else
     {
-        event = extend(true, clone(scaffold), event);
+        event = extend(true, clone(common), event);
     }
 
     if (!event.provenance) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ index.js: telemetry-events
 
 The MIT License (MIT)
 
-Copyright (c) 2014 Tristan Slominski, Leora Pearson
+Copyright (c) 2014-2015 Tristan Slominski, Leora Pearson
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation
@@ -30,6 +30,9 @@ OTHER DEALINGS IN THE SOFTWARE.
 */
 
 "use strict";
+
+var clone = require("clone");
+var extend = require("extend");
 
 module.exports = TelemetryEvents;
 
@@ -65,11 +68,22 @@ function TelemetryEvents(config) {
 };
 
 /*
+  * `scaffold`: _Object_ _(Default: undefined)_ Optional scaffold to clone and
+      extend with the `event` data.
   * `event`: _Object_ Event to be emitted.
   * Return: _Object_ The event.
  */
-TelemetryEvents.prototype.emit = function emit(event) {
+TelemetryEvents.prototype.emit = function emit(scaffold, event)
+{
     var self = this;
+    if (event === undefined)
+    {
+        event = scaffold;
+    }
+    else
+    {
+        event = extend(true, clone(scaffold), event);
+    }
 
     if (!event.provenance) {
         event.provenance = [];

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   "devDependencies": {
     "nodeunit": "0.9.x"
   },
+  "dependencies": {
+    "clone": "1.0.2",
+    "extend": "3.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:tristanls/telemetry-events.git"

--- a/test/emit.js
+++ b/test/emit.js
@@ -4,7 +4,7 @@ emit.js - TelemetryEvents.emit() test
 
 The MIT License (MIT)
 
-Copyright (c) 2014 Tristan Slominski, Leora Pearson
+Copyright (c) 2014-2015 Tristan Slominski, Leora Pearson
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation
@@ -31,6 +31,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 "use strict";
 
+var clone = require("clone");
 var events = require('events');
 var TelemetryEvents = require('../index.js');
 
@@ -133,5 +134,42 @@ tests['returns event with extended provenance'] = function (test) {
     test.equal(event.provenance.length, 2, "should've added additional entry to 'event.provenance'");
     test.equal(event.provenance[1].module, "package-name");
     test.equal(event.provenance[1].version, "package-version");
+    test.done();
+};
+
+tests['clones and extends a scaffold if provided without altering the original'] = function(test)
+{
+    test.expect(5);
+    var telemetry = new TelemetryEvents(
+    {
+        package: {
+            name: "package-name",
+            version: "package-version"
+        }
+    });
+    var scaffold = {
+        some: "scaffold",
+        with: {
+            some: "data"
+        }
+    };
+    var originalScaffold = clone(scaffold);
+    var event = telemetry.emit(scaffold,
+    {
+        my: "event",
+        with: {
+            more: "data"
+        }
+    });
+    test.equal(Object.keys(event).length, 5, "expected 5 event parameters");
+    test.equal(event.some, "scaffold", "expected scaffold data to be present");
+    test.deepEqual(event.with,
+    {
+        some: "data",
+        more: "data"
+    }, "expected scaffold and event to be combined");
+    test.equal(event.my, "event", "expected event data to be present");
+    test.deepEqual(scaffold, originalScaffold,
+                   "expected scaffold object to be unmodified");
     test.done();
 };

--- a/test/emit.js
+++ b/test/emit.js
@@ -137,7 +137,7 @@ tests['returns event with extended provenance'] = function (test) {
     test.done();
 };
 
-tests['clones and extends a scaffold if provided without altering the original'] = function(test)
+tests['clones and extends common data if provided without altering the original'] = function(test)
 {
     test.expect(5);
     var telemetry = new TelemetryEvents(
@@ -147,14 +147,14 @@ tests['clones and extends a scaffold if provided without altering the original']
             version: "package-version"
         }
     });
-    var scaffold = {
-        some: "scaffold",
+    var common = {
+        some: "common data",
         with: {
             some: "data"
         }
     };
-    var originalScaffold = clone(scaffold);
-    var event = telemetry.emit(scaffold,
+    var original = clone(common);
+    var event = telemetry.emit(common,
     {
         my: "event",
         with: {
@@ -162,14 +162,14 @@ tests['clones and extends a scaffold if provided without altering the original']
         }
     });
     test.equal(Object.keys(event).length, 5, "expected 5 event parameters");
-    test.equal(event.some, "scaffold", "expected scaffold data to be present");
+    test.equal(event.some, "common data", "expected common data to be present");
     test.deepEqual(event.with,
     {
         some: "data",
         more: "data"
-    }, "expected scaffold and event to be combined");
+    }, "expected common and event to be combined");
     test.equal(event.my, "event", "expected event data to be present");
-    test.deepEqual(scaffold, originalScaffold,
-                   "expected scaffold object to be unmodified");
+    test.deepEqual(common, original,
+                   "expected common object to be unmodified");
     test.done();
 };


### PR DESCRIPTION
Solution: Build-in `extend(true, clone(scaffold), event)` pattern into the module.

Context:

When using lots of telemetry events, I found myself using the following pattern over and over again to get rid of common event boilerplate (using `extend` and `clone` modules):

```javascript
_telemetry.emit(extend(true, clone(_commonEventData),
{
  data: "unique to this event"
}));
```

This pull requests enables me to now write:

```javascript
_telemetry.emit(_commonEventData,
{
  data: "unique to this event"
});
```

... without breaking backwards compatibility.